### PR TITLE
Adding function to set the range row height.

### DIFF
--- a/range.go
+++ b/range.go
@@ -24,6 +24,10 @@ func (this *Range) Font() (out *Font) {
 	return nil
 }
 
+func (this *Range) PutRowHeight(o interface{}) {
+	oleutil.MustPutProperty((*ole.IDispatch)(this), "RowHeight", o)
+}
+
 func (this *Range) PutValue(o interface{}) {
 	oleutil.MustPutProperty((*ole.IDispatch)(this), "Value", o)
 }


### PR DESCRIPTION
Setting the excel row height is useful for when writing multiple
lines to a cell and printing the spreadsheet.